### PR TITLE
Rudimentary WCA Live implementation

### DIFF
--- a/src/apis.py
+++ b/src/apis.py
@@ -220,102 +220,106 @@ def wca_api_get_new_token(refresh_token):
     except KeyError:
         print('ERROR!! Failed to get competition information.\n\n Given error message: {}\n Message:{}\n\nScript aborted.'.format(json.loads(wca_request_token.text)['error'], json.loads(wca_request_token.text)['error_description']))
 
-### Cubecomps API
+### WCA Live API
+wcalive_api_url="https://live.worldcubeassociation.org/api"
+
+wcalive_default_headers={'content-type': 'application/json'}
+
+graphql_query_competitions=r"query Competitions { competitions { upcoming { ...competitionInfo } inProgress { ...competitionInfo } past { ...competitionInfo } } } fragment competitionInfo on Competition { id name schedule { startDate endDate } }"
+graphql_query_competitors=r"query Competition($competitionId: ID!) { competition(id: $competitionId) { name competitors { id name } } }"
+graphql_query_results=r"query Round($competitionId: ID!, $roundId: String!) { round(competitionId: $competitionId, roundId: $roundId) { _id id name event { _id id name } format { solveCount sortBy } results { _id ranking advancable attempts best average person { _id id name country { name iso2 } } recordTags { single average } } } }"
+
+def post_wcalive_api(gql_operation, gql_variables, gql_query):
+	post_body_raw = {"operationName": gql_operation, "variables": gql_variables, "query": gql_query}
+	post_body = json.dumps(post_body_raw)
+
+	resp = requests.post(wcalive_api_url, data=post_body, headers=wcalive_default_headers)
+	parsed_resp = resp.json()
+
+	return parsed_resp['data']
+
 # API to collect competitor information
 # Mostly used to update registration id for all competitors
-def get_competitor_information_from_cubecomps(cubecomps_id, competition_name):
-    cubecomps_id = 'http://cubecomps.com/live.php?cid={}'.format(cubecomps_id)
+def get_competitor_information_from_wcalive(wcalive_id, competition_name):
     competitors_api = []
-    try:
-        cubecomps_id.split('?')[1].split('&')[0].split('=')[1]
-    except IndexError:
-        print('ERROR! Not a valid cubecomps link, script continues without cubecomps.com information.')
-        return ([], False)
 
-    comp_id = split_cubecomps_id(cubecomps_id, 1, 0, 1)
-    cubecomps_api_url = 'https://m.cubecomps.com/api/v1/competitions/{}'.format(comp_id)
-    cubecomps_api = requests.get(cubecomps_api_url).json()
+    wcalive_variables = {"competitionId": wcalive_id}
+    wcalive_api = post_wcalive_api("Competition", wcalive_variables, graphql_query_competitors)
 
-    if cubecomps_api['name'].replace('-', ' ') != competition_name and cubecomps_api['name'].replace('-', '') != competition_name.replace(' ', '').replace('-', ' '):
-        print('Cubecomps link does not match given competition name/ID. Script uses fallback to registration ids from WCA website!')
-        use_cubecomps_ids = False
+    if wcalive_api['competition']['name'].replace('-', ' ') != competition_name and wcalive_api['competition']['name'].replace('-', '') != competition_name.replace(' ', '').replace('-', ' '):
+        print('WCA Live link does not match given competition name/ID. Script uses fallback to registration ids from WCA website!')
+        use_wcalive_ids = False
     else:
-        for competitor in cubecomps_api['competitors']:
+        for competitor in wcalive_api['competition']['competitors']:
             competitors_api.append({'name': competitor['name'], 'competitor_id': int(competitor['id'])})
-        use_cubecomps_ids = True
-    return (competitors_api, use_cubecomps_ids)
+        use_wcalive_ids = True
+    return (competitors_api, use_wcalive_ids)
 
 # API to collect information for one round to determine next rounds' competitors
-def get_round_information_from_cubecomps(cubecomps_id):
+def get_round_information_from_wcalive(previous_round_link):
     advancing_competitors_next_round = 0
     competitors_api = []
-    try:
-        print('Get round information from cubecomps.com...')
-        print('')
-        comp_id = split_cubecomps_id(cubecomps_id, 1, 0, 1)
-        event_id = split_cubecomps_id(cubecomps_id, 1, 1, 1)
-        round_id = split_cubecomps_id(cubecomps_id, 1, 2, 1)
-    except IndexError:
-        print('ERROR! Not a valid cubecomps link, script aborted.')
-        sys.exit()
     
-    cubecomps_api_url = 'https://m.cubecomps.com/api/v1/competitions/{}/events/{}/rounds/{}'.format(comp_id, event_id, round_id)
-    cubecomps_api = requests.get(cubecomps_api_url).json()
-    competition_name = cubecomps_api['competition_name']
-    competition_name_stripped = competition_name.replace(' ', '')
-    create_competition_folder(competition_name)
-    event_round_name = '{} - {}'.format(cubecomps_api['event_name'], cubecomps_api['round_name']) 
+    print('Get round information from live.worldcubeassociation.org...')
+    print('')
+
+    url_before_query = previous_round_link.split('?')[0]
+
+    clean_url = url_before_query.rstrip('/')
+    url_parts = clean_url.split('/')
+
+    wcalive_id = url_parts[-3]
+    current_round_id = url_parts[-1]
+
+    wcalive_variables = {"competitionId": wcalive_id, "roundId": current_round_id}
+    wcalive_api = post_wcalive_api("Round", wcalive_variables, graphql_query_results)
+
+    create_competition_folder(wcalive_id)
+    event_round_name = '{} - {}'.format(wcalive_api['round']['event']['name'], wcalive_api['round']['name']) 
     
-    for competitor in cubecomps_api['results']:
-        if competitor['top_position']:
+    for competitor in wcalive_api['round']['results']:
+        if competitor['advancable']:
             advancing_competitors_next_round += 1
-            competitors_api.append({'name': competitor['name'], 'competitor_id': int(competitor['competitor_id']), 'ranking': int(competitor['position'])})
+            competitors_api.append({'name': competitor['person']['name'], 'competitor_id': int(competitor['person']['id']), 'ranking': int(competitor['ranking'])})
             
-    return(cubecomps_api, competitors_api, event_round_name, advancing_competitors_next_round, competition_name, competition_name_stripped)
-
-def split_cubecomps_id(cubecomps_id, ind1, ind2, ind3):
-    return cubecomps_id.split('?')[ind1].split('&')[ind2].split('=')[ind3]
+    return (wcalive_api, competitors_api, event_round_name, advancing_competitors_next_round, wcalive_id, wcalive_id)
     
-# Get all competitions from cubecomps
-def get_cubecomps_competitions():
-    url = 'https://m.cubecomps.com/api/v1/competitions'
-    url_past = 'https://m.cubecomps.com/api/v1/competitions/past'
-    current_competitions = requests.get(url).json()
-    past_competitions = requests.get(url_past).json()
-    compbined_competitions = current_competitions.copy()
-    compbined_competitions.update(past_competitions)
-    return compbined_competitions
+# Get all competitions from WCA Live
+def get_wcalive_competitions():
+    gql_data = post_wcalive_api("Competitions", {}, graphql_query_competitions)
+    return gql_data['competitions']
 
-# Find cubecomps competition
-def get_cubecomps_competition(create_only_nametags, competition_name, competition_name_stripped):
-    cubecomps_id = ''
+# Find WCA Live competition
+def get_wcalive_competition(create_only_nametags, competition_name, competition_name_stripped):
+    wcalive_id = ''
     competitors_api = []
-    use_cubecomps_ids = False
-    
-    if not create_only_nametags:    
-        competitions_cubecomps = get_cubecomps_competitions()
-        for dates in competitions_cubecomps: 
-            for competition in competitions_cubecomps[dates]:
-                if competition_name_stripped[:-4] == competition['name'].replace(' ', '').replace('-', '') and competition_name_stripped[-4:] in competition['date']:
-                    cubecomps_id = competition['id'].replace('-', '')
+    use_wcalive_ids = False
+    if not create_only_nametags:
+        competitions_wcalive = get_wcalive_competitions()
+        for occurence in competitions_wcalive: 
+            for competition in competitions_wcalive[occurence]:
+                comp_title_matches = competition_name == competition['name']
+                comp_year_matches = competition_name_stripped[-4:] in competition['schedule']['startDate']
+                if comp_title_matches and comp_year_matches:
+                    wcalive_id = competition['id'].replace('-', '')
                     break
-    if cubecomps_id:
-        competitors_api, use_cubecomps_ids = get_competitor_information_from_cubecomps(cubecomps_id, competition_name)
+    if wcalive_id:
+        competitors_api, use_wcalive_ids = get_competitor_information_from_wcalive(wcalive_id, competition_name)
         if not competitors_api:
-            use_cubecomps_ids = False
+            use_wcalive_ids = False
             print('')
-            print('INFO! The competition was found on cubecomps. However, no registration information was uploaded. Uploading them before using this script ensures to have matching ids on all scoresheets and in cubecomps (which eases scoretaking a lot!).')
+            print('INFO! The competition was found on WCA Live. However, no registration information was uploaded. Uploading them before using this script ensures to have matching ids on all scoresheets and in WCA Live (which eases scoretaking a lot!).')
             print('')
         else:
-            use_cubecomps_ids = True
+            use_wcalive_ids = True
             print('')
-            print('INFO! Script found registration information on cubecomps.com. These registration ids will be used for scoresheets.')
+            print('INFO! Script found registration information on WCA Live. These registration ids will be used for scoresheets.')
             print('')
     else:
         print('')
-        print('INFO! Competition was not found on cubecomps. Using this script and upload registration information afterwards might cause faulty registration ids on scoresheets. Use on own risk.')
+        print('INFO! Competition was not found on WCA Live. Using this script and upload registration information afterwards might cause faulty registration ids on scoresheets. Use on own risk.')
         print('')
-    return (competitors_api, cubecomps_id, use_cubecomps_ids) 
+    return (competitors_api, wcalive_id, use_wcalive_ids)
 
 # Return if certain information should be used or not (by using y/n choice)
 def get_information(information_string):

--- a/src/main.py
+++ b/src/main.py
@@ -172,7 +172,7 @@ if new_creation or create_only_nametags:
         if two_sided_nametags:
             print('Using WCA registration and event information for competition {}.'.format(competition_name))
             
-        competitors_api, cubecomps_id, use_cubecomps_ids = apis.get_cubecomps_competition(create_only_nametags, competition_name, competition_name_stripped)
+        competitors_api, cubecomps_id, use_cubecomps_ids = apis.get_wcalive_competition(create_only_nametags, competition_name, competition_name_stripped)
             
         if not create_only_nametags:
             if parser_args.scrambler_signature or not parser_args.no_scrambler_signature:
@@ -246,7 +246,7 @@ elif reading_grouping_from_file_bool:
     else:
         competition_wcif_file = apis.get_wca_info(competition_name, competition_name_stripped, parser_args.access_token)
     
-    competitors_api, cubecomps_id, use_cubecomps_ids = apis.get_cubecomps_competition(create_only_nametags, competition_name, competition_name_stripped)
+    competitors_api, cubecomps_id, use_cubecomps_ids = apis.get_wcalive_competition(create_only_nametags, competition_name, competition_name_stripped)
 
 # Create schedule from wca website information
 elif create_only_schedule:
@@ -276,7 +276,7 @@ elif create_scoresheets_second_rounds_bool:
         cubecomps_id = parser_args.cubecomps
     else:
         cubecomps_id = input('Link to previous round: ')
-    cubecomps_api, competitors, event_round_name, advancing_competitors_next_round, competition_name, competition_name_stripped = apis.get_round_information_from_cubecomps(cubecomps_id)
+    cubecomps_api, competitors, event_round_name, advancing_competitors_next_round, competition_name, competition_name_stripped = apis.get_round_information_from_wcalive(cubecomps_id)
     
     event_2 = event_round_name.split(' - ')[0].replace(' Cube', '')
     event_2 = list(event_dict.keys())[list(event_dict.values()).index(event_2)]


### PR DESCRIPTION
Use the new wca-live scoretaking website as backend for consecutive rounds instead of the deprecated cubecomps API.

Tested successfully without any problem at all at BremiumWinter2019

The API calls are modified and re-routed to the (undocumented!) GraphQL API by WCA Live. The necessary endpoints were mostly reverse-engineered by me on a boring Tuesday evening. The main structure of the program is left untouched, so the routines like scorecard generation potentially think they are still talking to cubecomps. The methods have only been renamed for human purposes.

### Remarks:
- We *could* use the IDs directly from the WCIF, as WCA-Live just mirrors them anyways. However, I did not want to refactor the entire ID assignment process for all script files, so right now we still rely on this second, distinct set of "scoretaking IDs". The fact that they coincide with registration IDs is just a "happy coincidence" :)
- Only known quirk: The WCA Live API for individual Rounds does not exhibit the "readable" competition name, only its ID. This behaviour is propagated to the top left corner of some scoresheets. It **does work** correctly for initial creation of the big set of cards, because those also query a second "competition info" WCA Live API that includes the human readable competition name.